### PR TITLE
Grammar: Add Extension `gv`

### DIFF
--- a/Syntaxes/DOT.plist
+++ b/Syntaxes/DOT.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>dot</string>
 		<string>DOT</string>
+		<string>gv</string>
 	</array>
 	<key>firstLineMatch</key>
 	<string>digraph.*</string>


### PR DESCRIPTION
Hi,

this pull request adds the extension `gv` to the Graphviz grammar. If I should change anything, please just comment below. Thank you.

Kind regards,
  René
